### PR TITLE
Fix cron tags

### DIFF
--- a/CronController.php
+++ b/CronController.php
@@ -213,13 +213,12 @@ RAW;
      */
     public function actionRun($args = array()){
 
-        //if no args enterred then use default
-        //else enter the string of args into the array
-        if (empty($args)){
-            $tags[] = 'default';
-        } else {
+        //always run default values
+        $tags[] = 'default';
+        //if we have specified args in input (cron-tags) insert them in array
+        if (!empty($args)){
             $tags[] = &$args;
-        }
+         }
 
         //Getting timestamp will be used as current
         $time = strtotime($this->timestamp);

--- a/CronController.php
+++ b/CronController.php
@@ -212,8 +212,14 @@ RAW;
      * @param array $args List of run-tags to running actions (if empty, only "default" run-tag will be runned).
      */
     public function actionRun($args = array()){
-        $tags = &$args;
-        $tags[] = 'default';
+
+        //if no args enterred then use default
+        //else enter the string of args into the array
+        if (empty($args)){
+            $tags[] = 'default';
+        } else {
+            $tags[] = &$args;
+        }
 
         //Getting timestamp will be used as current
         $time = strtotime($this->timestamp);

--- a/CronController.php
+++ b/CronController.php
@@ -240,6 +240,11 @@ RAW;
                 else                                $stdout = $this->logFileName;
 
                 $stdout = $this->formatFileName($stdout, $task);
+                //if stdout does not exist then create the file
+                if (!file_exists($stdout)){
+                    touch($stdout);
+                }
+
                 if(!is_writable($stdout)) {
                     $stdout = '/dev/null';
                 }

--- a/CronController.php
+++ b/CronController.php
@@ -28,6 +28,11 @@ class CronController extends Controller {
     public $logsDir = null;
 
     /**
+     * @var string path for category for logging
+     */
+    public $logsCategory = 'yii2-cronjobs';
+
+    /**
      * Update or rewrite log file
      * False - rewrite True - update(add to end logs)
      * @var bool
@@ -214,7 +219,6 @@ RAW;
     public function actionRun($args = array()){
         $tags = &$args;
         $tags[] = 'default';
-
         //Getting timestamp will be used as current
         $time = strtotime($this->timestamp);
         if ($time === false) throw new CException('Bad timestamp format');
@@ -244,15 +248,16 @@ RAW;
                 if(!is_writable($stderr)) {
                     $stdout = '/dev/null';
                 }
+
                 $this->runCommandBackground($command, $stdout, $stderr);
-                Yii::info('Running task ['.(++$runned).']: '.$task['command'].' '.$task['action']);
+                Yii::info('Running task ['.(++$runned).']: '.$task['command'].' '.$task['action'],$this->logsCategory);
             }
         }
         if ($runned > 0){
-            Yii::info('Runned '.$runned.' task(s) at '.date('r', $time));
+            Yii::info('Runned '.$runned.' task(s) at '.date('r', $time),$this->logsCategory);
         }
         else{
-            Yii::info('No task on '.date('r', $time));
+            Yii::info('No task on '.date('r', $time),$this->logsCategory);
         }
     }
 


### PR DESCRIPTION
Running php yii cron live 
will fail atthe moment.

This is a fix that fixes this.

If we specify cron-tags in string format in the cronJobs 

```
        'mytest/index' =>[
            'cron'          => '* * * * *',
            'cron-tags'     => 'live staging',
        ]
```

then running php yii cron live will trigger this job
